### PR TITLE
fix: adds releaserc for explicity plugin definition

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,6 @@
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/npm",
     ["@semantic-release/github", {
       "assets": [
         {"path": "build/**", "label": "Build artifacts"}


### PR DESCRIPTION
Removes the npm plugin as we dont use that for now. 