### PR TITLE
chore: set the prepare script to run the build for npx usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "npm run build && npm run start",
     "test": "node -r dotenv/config tests/test-direct-api.js",
     "setup-claude": "node -r dotenv/config scripts/setup-claude-config.sh",
-    "prepare": "husky install"
+    "prepare": "npm run build"
   },
   "keywords": [],
   "author": "Smartsheet",


### PR DESCRIPTION
This is to enable mcp configuration via


```{
    "mcpServers": {
      "smartsheet": {
        "command": "npx",
        "args": ["-y", "github.com/smar-imran-khawaja/smar-mcp"],
        "env": {
          "SMARTSHEET_API_KEY": "YOUR_SMARTSHEET_API_KEY"
        }
      }
    }
  }```