### PR TITLE
fix(tools): add missing inputSchema on get_current_user and list_users (#79)

### DIFF
--- a/src/tools/__tests__/tool-registration-shape.test.ts
+++ b/src/tools/__tests__/tool-registration-shape.test.ts
@@ -1,0 +1,80 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SmartsheetAPI } from '../../apis/smartsheet-api.js';
+import { getUserTools } from '../smartsheet-user-tools.js';
+import { getSheetTools } from '../smartsheet-sheet-tools.js';
+import { getSearchTools } from '../smartsheet-search-tools.js';
+import { getFolderTools } from '../smartsheet-folder-tools.js';
+import { getWorkspaceTools } from '../smartsheet-workspace-tools.js';
+import { getDiscussionTools } from '../smartsheet-discussion-tools.js';
+import { getUpdateRequestTools } from '../smartsheet-update-request-tools.js';
+
+jest.mock('../../apis/smartsheet-api.js');
+
+/**
+ * Anti-regression test: every server.tool() call must use the 4-arg signature
+ * (name, description, inputSchema, handler).
+ *
+ * Calling server.tool(name, description, handler) without an inputSchema causes
+ * the MCP SDK to register a tool with no/invalid JSON schema, which breaks
+ * downstream consumers such as @langchain/core/tools (see issue #79). This test
+ * captures every registration and asserts the third argument is an object
+ * (the inputSchema map) rather than a function (the handler).
+ */
+
+type AnyArgs = unknown[];
+
+interface CapturedRegistration {
+  name: string;
+  args: AnyArgs;
+}
+
+function captureFromRegistrar(register: (server: McpServer, api: SmartsheetAPI) => void): CapturedRegistration[] {
+  const captured: CapturedRegistration[] = [];
+  const mockServer = {
+    tool: jest.fn((...args: AnyArgs) => {
+      captured.push({ name: String(args[0]), args });
+    }),
+  } as unknown as McpServer;
+  const mockApi = {} as SmartsheetAPI;
+  register(mockServer, mockApi);
+  return captured;
+}
+
+const TOOL_REGISTRARS: Array<{
+  fileLabel: string;
+  register: (server: McpServer, api: SmartsheetAPI) => void;
+}> = [
+  { fileLabel: 'smartsheet-user-tools', register: getUserTools },
+  {
+    fileLabel: 'smartsheet-sheet-tools',
+    register: (s, a) => getSheetTools(s, a, false),
+  },
+  { fileLabel: 'smartsheet-search-tools', register: getSearchTools },
+  { fileLabel: 'smartsheet-folder-tools', register: getFolderTools },
+  { fileLabel: 'smartsheet-workspace-tools', register: getWorkspaceTools },
+  { fileLabel: 'smartsheet-discussion-tools', register: getDiscussionTools },
+  { fileLabel: 'smartsheet-update-request-tools', register: getUpdateRequestTools },
+];
+
+describe('server.tool() registrations have a valid input schema', () => {
+  describe.each(TOOL_REGISTRARS)('$fileLabel', ({ register }) => {
+    const registrations = captureFromRegistrar(register);
+
+    it('registers at least one tool', () => {
+      expect(registrations.length).toBeGreaterThan(0);
+    });
+
+    it.each(registrations.map((r) => [r.name, r] as const))(
+      '%s passes an inputSchema object as the 3rd argument',
+      (_name, registration) => {
+        const [toolName, description, third, fourth] = registration.args;
+        expect(typeof toolName).toBe('string');
+        expect(typeof description).toBe('string');
+        expect(typeof third).toBe('object');
+        expect(third).not.toBeNull();
+        expect(Array.isArray(third)).toBe(false);
+        expect(typeof fourth).toBe('function');
+      }
+    );
+  });
+});

--- a/src/tools/smartsheet-user-tools.ts
+++ b/src/tools/smartsheet-user-tools.ts
@@ -8,6 +8,7 @@ export function getUserTools(server: McpServer, api: SmartsheetAPI) {
     server.tool(
         "get_current_user",
         "Gets the current user's information",
+        {},
         async () => {
         try {
             console.info("Getting current user");
@@ -74,6 +75,7 @@ export function getUserTools(server: McpServer, api: SmartsheetAPI) {
     server.tool(
         "list_users",
         "Lists all users",
+        {},
         async () => {
             try {
                 console.info("Listing all users");


### PR DESCRIPTION
👋 Hi Smartsheet team,

First-time contributor here. I'm a Smartsheet power user running daily AI workflows on top of `smar-mcp` (Claude + LangChain), and I noticed a handful of small papercuts while integrating the server into my agentic stack. Rather than just opening issues, I figured I'd send the fixes directly.

This is the **first of 3 small, independent PRs** I'd like to contribute over the next few days:

1. **This PR** — fixes #79 (invalid input schema on 2 user tools breaking LangChain integration) + adds an anti-regression test that prevents the bug from coming back on any future tool.
2. **Coming next** — Jest tests for `url-utils.ts` to help PR #88 (EU region auth fix) land. A few users have flagged that one as blocking.
3. **Coming after** — proposal to make the release pipeline tolerant of `NPM_TOKEN` issues (root cause of #94).

Each PR is fully self-contained and can be reviewed/merged independently. Happy to iterate on style, scope, or split things further if it helps. Thanks for open-sourcing this — really enjoying building on top of it. 🙏

---

## Summary

Two `server.tool()` calls in `smartsheet-user-tools.ts` were registered without an `inputSchema` argument:

- `get_current_user`
- `list_users`

This causes the MCP SDK to register tools with an invalid/empty JSON schema, which breaks downstream consumers like `@langchain/core/tools` (issue #79: `Error: Invalid schema type or missing properties`).

## Fix

Added `{}` as the inputSchema for both tools (these tools take no parameters). Matches the pattern already used by `get_workspaces` in `smartsheet-workspace-tools.ts`.

## Anti-regression test

Added `src/tools/__tests__/tool-registration-shape.test.ts` that loads **every** tool registrar in the codebase and asserts the 4-arg signature `server.tool(name, description, inputSchema, handler)` is used. Without the fix, this test fails on exactly the 2 affected tools.

Going forward, any new tool added without a schema will fail CI immediately.

## Test plan

- [x] `npm test` → 79 passed (was 39, +40 from new file)
- [x] `npm run typecheck` clean
- [x] `npx eslint` clean on changed files
- [x] Confirmed test fails on `main` without the fix (2 failures on the affected tools), passes with the fix

Closes #79. Builds on the diagnosis from #80 by @rickliujh, adds anti-regression coverage to prevent recurrence.
