### PR TITLE
feat: EU region URL validation + unit tests (continuation of #88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,12 @@
 # You can obtain a token from the Smartsheet Developer Portal: https://developers.smartsheet.com/
 SMARTSHEET_API_KEY=your_smartsheet_api_token_here
 
-# The smartsheet API endpoint, such as https://api.smartsheet.com/2.0/, https://api.smartsheet.eu/2.0/
-SMARTSHEET_ENDPOINT=https://api.test.smartsheet.com/2.0
+# Smartsheet API endpoint (required)
+# US region: https://api.smartsheet.com/2.0
+# EU region: https://api.smartsheet.eu/2.0
+# IMPORTANT: Your API token is region-specific. Use the endpoint matching your account's region.
+# EU accounts use app.smartsheet.eu and require the EU API endpoint.
+SMARTSHEET_ENDPOINT=https://api.smartsheet.com/2.0
 
 # Control whether deletion operations are enabled (true/false)
 # When not set or set to false, delete_rows tool will not be available

--- a/claude_desktop_config-example.json
+++ b/claude_desktop_config-example.json
@@ -1,10 +1,11 @@
 {
     "mcpServers": {
       "smartsheet": {
-        "command": "ABSOLUTE_PATH_TO_NODE", // e.g., "/Users/imkhawaja/.volta/bin/node"
-        "args": ["-r", "/Users/imkhawaja/repos/learnmcp/node/smar-mcp/node_modules/dotenv/config", "/Users/imkhawaja/repos/learnmcp/node/smar-mcp/build/index.js"],
+        "command": "ABSOLUTE_PATH_TO_NODE",
+        "args": ["-r", "ABSOLUTE_PATH_TO_SMAR_MCP/node_modules/dotenv/config", "ABSOLUTE_PATH_TO_SMAR_MCP/build/index.js"],
         "env": {
-          "SMARTSHEET_API_KEY": "YOUR_SMARTSHEET_API_KEY"
+          "SMARTSHEET_API_KEY": "YOUR_SMARTSHEET_API_KEY",
+          "SMARTSHEET_ENDPOINT": "https://api.smartsheet.com/2.0"
         }
       }
     }

--- a/src/apis/smartsheet-api.ts
+++ b/src/apis/smartsheet-api.ts
@@ -5,6 +5,7 @@ import { SmartsheetSearchAPI } from './smartsheet-search-api.js';
 import { SmartsheetSheetAPI } from './smartsheet-sheet-api.js';
 import { SmartsheetWorkspaceAPI } from './smartsheet-workspace-api.js';
 import { SmartsheetUserAPI } from './smartsheet-user-api.js';
+import { detectApiRegion, type SmartsheetRegion } from '../utils/url-utils.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 /**
@@ -13,6 +14,7 @@ import packageJson from '../../package.json' with { type: 'json' };
 export class SmartsheetAPI {
   private baseUrl: string;
   private accessToken: string;
+  public readonly region: SmartsheetRegion;
   public sheets: SmartsheetSheetAPI;
   public workspaces: SmartsheetWorkspaceAPI;
   public folders: SmartsheetFolderAPI;
@@ -27,6 +29,7 @@ export class SmartsheetAPI {
   constructor(accessToken?: string, baseUrl?: string) {
     this.baseUrl = baseUrl || '';
     this.accessToken = accessToken || '';
+    this.region = detectApiRegion(this.baseUrl);
     this.sheets = new SmartsheetSheetAPI(this);
     this.workspaces = new SmartsheetWorkspaceAPI(this);
     this.folders = new SmartsheetFolderAPI(this);

--- a/src/tools/smartsheet-search-tools.ts
+++ b/src/tools/smartsheet-search-tools.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SmartsheetAPI } from "../apis/smartsheet-api.js";
 import { z } from "zod";
+import { parseSmartsheetUrl, validateRegionMatch } from "../utils/url-utils.js";
 
 export function getSearchTools(server: McpServer, api: SmartsheetAPI) {
 
@@ -83,20 +84,31 @@ export function getSearchTools(server: McpServer, api: SmartsheetAPI) {
         async ({ url, query }) => {
         try {
             console.info(`Searching for sheet with URL: ${url} with query: ${query}`);
-            const match = url.match(/\/sheets\/([^?/]+)/);
-            const directIdToken = match ? match[1] : null;
-            if (!directIdToken) {
+            const parsed = parseSmartsheetUrl(url);
+            if (!parsed) {
                 return {
                     content: [
                         {
                             type: "text",
-                            text: `Failed to get sheet: Invalid URL format`
+                            text: `Failed to get sheet: Invalid URL format. Expected a Smartsheet URL containing /sheets/{id}`
                         }
                     ],
                     isError: true
                 };
             }
-            const sheet = await api.sheets.getSheetByDirectIdToken(directIdToken);
+            const regionError = validateRegionMatch(parsed.region, api.region);
+            if (regionError) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Failed to search in sheet: ${regionError}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            const sheet = await api.sheets.getSheetByDirectIdToken(parsed.directIdToken);
             const results = await api.search.searchSheet(sheet.id, query);
             
             return {
@@ -164,21 +176,32 @@ export function getSearchTools(server: McpServer, api: SmartsheetAPI) {
         },
         async ({ url }) => {
         try {
-            const user = await api.users.getCurrentUser();
-            const match = url.match(/\/sheets\/([^?/]+)/);
-            const directIdToken = match ? match[1] : null;
-            if (!directIdToken) {
+            const parsed = parseSmartsheetUrl(url);
+            if (!parsed) {
                 return {
                     content: [
                         {
                             type: "text",
-                            text: `Failed to get sheet: Invalid URL format`
+                            text: `Failed to get sheet: Invalid URL format. Expected a Smartsheet URL containing /sheets/{id}`
                         }
                     ],
                     isError: true
                 };
             }
-            const sheet = await api.sheets.getSheetByDirectIdToken(directIdToken);
+            const regionError = validateRegionMatch(parsed.region, api.region);
+            if (regionError) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Failed to search for assigned tasks: ${regionError}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            const user = await api.users.getCurrentUser();
+            const sheet = await api.sheets.getSheetByDirectIdToken(parsed.directIdToken);
             const results = await api.search.searchSheet(sheet.id, user.email);
             
             return {

--- a/src/tools/smartsheet-sheet-tools.ts
+++ b/src/tools/smartsheet-sheet-tools.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SmartsheetAPI } from "../apis/smartsheet-api.js";
 import { z } from "zod";
+import { parseSmartsheetUrl, validateRegionMatch } from "../utils/url-utils.js";
 
 export function getSheetTools(server: McpServer, api: SmartsheetAPI, allowDeleteTools: boolean) {
 
@@ -53,20 +54,31 @@ export function getSheetTools(server: McpServer, api: SmartsheetAPI, allowDelete
       async ({ url, include, pageSize, page }) => {
         try {
           console.info(`Getting sheet with URL: ${url}`);
-          const match = url.match(/\/sheets\/([^?/]+)/);
-          const directIdToken = match ? match[1] : null;
-          if (!directIdToken) {
+          const parsed = parseSmartsheetUrl(url);
+          if (!parsed) {
             return {
               content: [
                 {
                   type: "text",
-                  text: `Failed to get sheet: Invalid URL format`
+                  text: `Failed to get sheet: Invalid URL format. Expected a Smartsheet URL containing /sheets/{id}`
                 }
               ],
               isError: true
             };
           }
-          const sheet = await api.sheets.getSheetByDirectIdToken(directIdToken, include, undefined, pageSize, page);
+          const regionError = validateRegionMatch(parsed.region, api.region);
+          if (regionError) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Failed to get sheet: ${regionError}`
+                }
+              ],
+              isError: true
+            };
+          }
+          const sheet = await api.sheets.getSheetByDirectIdToken(parsed.directIdToken, include, undefined, pageSize, page);
           
           return {
             content: [

--- a/src/utils/__tests__/url-utils.test.ts
+++ b/src/utils/__tests__/url-utils.test.ts
@@ -1,0 +1,211 @@
+import {
+  parseSmartsheetUrl,
+  detectApiRegion,
+  regionLabel,
+  validateRegionMatch,
+  type SmartsheetRegion,
+} from '../url-utils.js';
+
+describe('parseSmartsheetUrl', () => {
+  describe('valid URLs - US region', () => {
+    it('parses a standard US sheet URL', () => {
+      const result = parseSmartsheetUrl(
+        'https://app.smartsheet.com/sheets/abc123XYZ'
+      );
+      expect(result).toEqual({ directIdToken: 'abc123XYZ', region: 'us' });
+    });
+
+    it('parses a US URL with query string', () => {
+      const result = parseSmartsheetUrl(
+        'https://app.smartsheet.com/sheets/token123?view=grid'
+      );
+      expect(result).toEqual({ directIdToken: 'token123', region: 'us' });
+    });
+
+    it('parses a US URL with trailing path segments', () => {
+      const result = parseSmartsheetUrl(
+        'https://app.smartsheet.com/sheets/token456/details'
+      );
+      expect(result).toEqual({ directIdToken: 'token456', region: 'us' });
+    });
+
+    it('treats unknown hostnames as US by default', () => {
+      const result = parseSmartsheetUrl(
+        'https://app.example.com/sheets/foo'
+      );
+      expect(result).toEqual({ directIdToken: 'foo', region: 'us' });
+    });
+  });
+
+  describe('valid URLs - EU region', () => {
+    it('parses a standard EU sheet URL', () => {
+      const result = parseSmartsheetUrl(
+        'https://app.smartsheet.eu/sheets/euToken789'
+      );
+      expect(result).toEqual({ directIdToken: 'euToken789', region: 'eu' });
+    });
+
+    it('detects EU region case-insensitively', () => {
+      const result = parseSmartsheetUrl(
+        'https://APP.SMARTSHEET.EU/sheets/MixedCase'
+      );
+      expect(result).toEqual({ directIdToken: 'MixedCase', region: 'eu' });
+    });
+
+    it('parses an EU URL with query string', () => {
+      const result = parseSmartsheetUrl(
+        'https://app.smartsheet.eu/sheets/euTok?ss_d=abc'
+      );
+      expect(result).toEqual({ directIdToken: 'euTok', region: 'eu' });
+    });
+  });
+
+  describe('invalid URLs', () => {
+    it('returns null for a URL without /sheets/', () => {
+      expect(parseSmartsheetUrl('https://app.smartsheet.com/dashboards/123'))
+        .toBeNull();
+    });
+
+    it('returns null for a malformed URL with no sheet token', () => {
+      expect(parseSmartsheetUrl('not a url at all')).toBeNull();
+    });
+
+    it('returns null for an empty string', () => {
+      expect(parseSmartsheetUrl('')).toBeNull();
+    });
+
+    it('returns null for a URL with /sheets/ but no token', () => {
+      expect(parseSmartsheetUrl('https://app.smartsheet.com/sheets/'))
+        .toBeNull();
+    });
+  });
+
+  describe('fallback path (URL constructor failure)', () => {
+    it('still detects EU region from a non-URL string containing smartsheet.eu', () => {
+      const result = parseSmartsheetUrl('app.smartsheet.eu/sheets/fallbackToken');
+      expect(result).toEqual({
+        directIdToken: 'fallbackToken',
+        region: 'eu',
+      });
+    });
+
+    it('defaults to US for non-URL string without EU marker', () => {
+      const result = parseSmartsheetUrl('app.smartsheet.com/sheets/usFallback');
+      expect(result).toEqual({
+        directIdToken: 'usFallback',
+        region: 'us',
+      });
+    });
+  });
+});
+
+describe('detectApiRegion', () => {
+  it('returns "us" for the canonical US API endpoint', () => {
+    expect(detectApiRegion('https://api.smartsheet.com/2.0')).toBe('us');
+  });
+
+  it('returns "eu" for the canonical EU API endpoint', () => {
+    expect(detectApiRegion('https://api.smartsheet.eu/2.0')).toBe('eu');
+  });
+
+  it('detects EU from hostname containing smartsheet.eu', () => {
+    expect(detectApiRegion('https://api-staging.smartsheet.eu/2.0')).toBe('eu');
+  });
+
+  it('detects EU from hostnames ending in .eu', () => {
+    expect(detectApiRegion('https://api.smartsheet.eu/2.0')).toBe('eu');
+  });
+
+  it('returns "us" for unknown hostnames as a safe default', () => {
+    expect(detectApiRegion('https://api.example.com/2.0')).toBe('us');
+  });
+
+  it('falls back to EU detection on malformed URL with smartsheet.eu', () => {
+    expect(detectApiRegion('not-a-url-but-contains-smartsheet.eu'))
+      .toBe('eu');
+  });
+
+  it('falls back to US for malformed URLs without EU marker', () => {
+    expect(detectApiRegion('not-a-url')).toBe('us');
+  });
+
+  it('handles hostnames case-insensitively', () => {
+    expect(detectApiRegion('https://API.SMARTSHEET.EU/2.0')).toBe('eu');
+  });
+});
+
+describe('regionLabel', () => {
+  it('returns "US" for the us region', () => {
+    expect(regionLabel('us')).toBe('US');
+  });
+
+  it('returns "EU" for the eu region', () => {
+    expect(regionLabel('eu')).toBe('EU');
+  });
+});
+
+describe('validateRegionMatch', () => {
+  it('returns null when regions match (us/us)', () => {
+    expect(validateRegionMatch('us', 'us')).toBeNull();
+  });
+
+  it('returns null when regions match (eu/eu)', () => {
+    expect(validateRegionMatch('eu', 'eu')).toBeNull();
+  });
+
+  describe('mismatch: EU URL with US endpoint', () => {
+    let message: string;
+    beforeAll(() => {
+      message = validateRegionMatch('eu', 'us') as string;
+    });
+
+    it('returns a non-null error message', () => {
+      expect(message).not.toBeNull();
+      expect(typeof message).toBe('string');
+    });
+
+    it('mentions both regions clearly', () => {
+      expect(message).toContain('EU region');
+      expect(message).toContain('US region');
+    });
+
+    it('suggests the correct EU endpoint', () => {
+      expect(message).toContain('https://api.smartsheet.eu/2.0');
+    });
+
+    it('explains why a region-specific token is required', () => {
+      expect(message).toContain('EU API token');
+    });
+  });
+
+  describe('mismatch: US URL with EU endpoint', () => {
+    let message: string;
+    beforeAll(() => {
+      message = validateRegionMatch('us', 'eu') as string;
+    });
+
+    it('returns a non-null error message', () => {
+      expect(message).not.toBeNull();
+    });
+
+    it('suggests the correct US endpoint', () => {
+      expect(message).toContain('https://api.smartsheet.com/2.0');
+    });
+
+    it('explains a US token is required', () => {
+      expect(message).toContain('US API token');
+    });
+  });
+
+  it('produces a helpful diagnostic for every region pair', () => {
+    const pairs: Array<[SmartsheetRegion, SmartsheetRegion]> = [
+      ['us', 'eu'],
+      ['eu', 'us'],
+    ];
+    for (const [urlRegion, apiRegion] of pairs) {
+      const msg = validateRegionMatch(urlRegion, apiRegion);
+      expect(msg).toMatch(/Region mismatch/);
+      expect(msg).toMatch(/SMARTSHEET_ENDPOINT/);
+    }
+  });
+});

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,0 +1,92 @@
+export type SmartsheetRegion = 'us' | 'eu';
+
+export interface ParsedSmartsheetUrl {
+  directIdToken: string;
+  region: SmartsheetRegion;
+}
+
+const FRONTEND_HOST_REGION: Record<string, SmartsheetRegion> = {
+  'app.smartsheet.com': 'us',
+  'app.smartsheet.eu': 'eu',
+};
+
+const API_HOST_REGION: Record<string, SmartsheetRegion> = {
+  'api.smartsheet.com': 'us',
+  'api.smartsheet.eu': 'eu',
+};
+
+/**
+ * Parses a Smartsheet frontend URL, extracting the directIdToken and detecting
+ * the region (US: app.smartsheet.com, EU: app.smartsheet.eu).
+ */
+export function parseSmartsheetUrl(url: string): ParsedSmartsheetUrl | null {
+  const tokenMatch = url.match(/\/sheets\/([^?\/]+)/);
+  if (!tokenMatch) {
+    return null;
+  }
+
+  const directIdToken = tokenMatch[1];
+  let region: SmartsheetRegion = 'us';
+
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    if (FRONTEND_HOST_REGION[hostname]) {
+      region = FRONTEND_HOST_REGION[hostname];
+    }
+  } catch {
+    if (url.includes('smartsheet.eu')) {
+      region = 'eu';
+    }
+  }
+
+  return { directIdToken, region };
+}
+
+export function detectApiRegion(apiBaseUrl: string): SmartsheetRegion {
+  try {
+    const parsed = new URL(apiBaseUrl);
+    const hostname = parsed.hostname.toLowerCase();
+
+    if (API_HOST_REGION[hostname]) {
+      return API_HOST_REGION[hostname];
+    }
+
+    if (hostname.includes('smartsheet.eu') || hostname.includes('.eu')) {
+      return 'eu';
+    }
+  } catch {
+    if (apiBaseUrl.includes('smartsheet.eu')) {
+      return 'eu';
+    }
+  }
+
+  return 'us';
+}
+
+export function regionLabel(region: SmartsheetRegion): string {
+  return region === 'eu' ? 'EU' : 'US';
+}
+
+/**
+ * Returns an error message if the frontend URL region doesn't match the configured
+ * API endpoint region, or null if they match. Region mismatches cause auth failures
+ * because Smartsheet API keys are region-specific.
+ */
+export function validateRegionMatch(
+  urlRegion: SmartsheetRegion,
+  apiRegion: SmartsheetRegion
+): string | null {
+  if (urlRegion !== apiRegion) {
+    const urlLabel = regionLabel(urlRegion);
+    const apiLabel = regionLabel(apiRegion);
+    return (
+      `Region mismatch: the Smartsheet URL points to the ${urlLabel} region, ` +
+      `but your SMARTSHEET_ENDPOINT is configured for the ${apiLabel} region. ` +
+      `${urlLabel} sheets require a ${urlLabel} API token and endpoint. ` +
+      `Set SMARTSHEET_ENDPOINT to https://api.smartsheet.${urlRegion === 'eu' ? 'eu' : 'com'}/2.0 ` +
+      `and use a ${urlLabel} API token.`
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
👋 PR #2 of 3 from a Smartsheet power user (see #95 for context).

This PR is **complementary to #88** by @is-isaac — it cherry-picks his 3 commits (attribution preserved as `Sisyphus <clio-agent@sisyphuslabs.ai>`, the original commit author) and adds the missing piece blocking the merge: **unit tests for `url-utils.ts`**.

## Why a separate PR rather than commenting on #88

PR #88 has been open since February with no reviewer activity, and several users in #87 / #92 are blocked by the same EU auth bug. Re-bundling the code with tests (resolved against current `main`) gives reviewers a single clean PR to merge. If you'd rather pull just the test commit onto #88 directly, please feel free — happy either way.

## What's in here

- **Commits 1-3** (cherry-pick of #88 by @is-isaac, conflicts with current `main` already resolved):
  - `feat: add URL utility with EU/US region detection`
  - `fix: add EU region validation to URL-based tools`
  - `docs: add EU region endpoint to config examples`
- **Commit 4** (new): `test(utils): add Jest coverage for url-utils` — 33 unit tests:
  - `parseSmartsheetUrl`: US/EU detection, query strings, trailing path segments, case-insensitive hostnames, malformed URLs returning `null`, URL-constructor fallback path.
  - `detectApiRegion`: canonical US/EU endpoints, generic `.eu` hostnames, malformed input fallback, case-insensitive matching.
  - `regionLabel` + `validateRegionMatch`: matching and mismatched pairs in both directions; asserts the diagnostic mentions both regions, suggests the corrected `SMARTSHEET_ENDPOINT`, and explains a region-specific token is required.

## Why this matters

Region mismatches between `SMARTSHEET_ENDPOINT` and the URL passed to `get_sheet_by_url`/`search_in_sheet_by_url`/`what_am_i_assigned_to_by_sheet_url` produce silent 401s today. After this change:
- EU users get an **actionable error** telling them exactly which env var to update.
- Same diagnostic for US users who accidentally point at `api.smartsheet.eu`.
- The `region` is exposed as `api.region` so downstream tools can do their own validation.

## Test plan

- [x] `npm test` → **72/72** passed (3 suites, +33 tests from this PR)
- [x] `npm run typecheck` → clean
- [x] Verified the diagnostic copy renders correctly for both `eu→us` and `us→eu` mismatches
- [x] Tested the fallback path with malformed URLs (URL constructor throws)

Closes the testing gap on #88. Refs #87, #92 (EU auth reports).
